### PR TITLE
Instead of returning null, make baseobject throw an exception when somet...

### DIFF
--- a/src/main/php/DataSift/Stone/ObjectLib/BaseObject.php
+++ b/src/main/php/DataSift/Stone/ObjectLib/BaseObject.php
@@ -313,10 +313,10 @@ class BaseObject extends stdClass
      * that doesn't actually exist
      *
      * @param  string $property name of the property being read
-     * @return null
+     * @throws \Exception
      */
     public function __get($property)
     {
-        return null;
+        throw new \Exception("Property does not exist in object: '".$property."'");
     }
 }


### PR DESCRIPTION
...hing's not found
