### PR TITLE
compare string against a set of possible values

### DIFF
--- a/src/php/DataSift/Stone/ComparisonLib/StringComparitor.php
+++ b/src/php/DataSift/Stone/ComparisonLib/StringComparitor.php
@@ -363,4 +363,31 @@ class StringComparitor extends ComparitorBase
 		// success - the starts are different
 		return $result;
 	}
+
+	/**
+	* Given an array of possible values, is the current value in the list of possibilities?
+	*
+	* @param  array $expected the array/list of possible values $this->value could be equal to in
+	* order to pass
+	* @return ComparisonResult
+	*/
+	public function isIn($expected = array())
+	{
+		$result = $this->isExpectedType();
+		if ($result->hasFailed()) {
+			return $result;
+		}
+
+		if(count($expected) == 0){
+			return $result;
+		}
+
+		foreach ($expected as $possibleValue) {
+			if($this->value == $possibleValue){
+				$result->setHasPassed();
+				break;
+			}
+		}
+		return $result;
+	}	
 }


### PR DESCRIPTION
adds a function which compares a string against a set of possible values.
An example use case is when with the DS push API where both finishing and finished are valid states after calling the stop endpoint.
Usage

``` php

$st->assertsString($response->body->status)->isIn(array("finishing", "finished"));

```
