### PR TITLE
Fix issue in HttpDefaultTransport where response bodies are truncated.

### DIFF
--- a/src/php/DataSift/Stone/HttpLib/Transports/HttpDefaultTransport.php
+++ b/src/php/DataSift/Stone/HttpLib/Transports/HttpDefaultTransport.php
@@ -91,7 +91,7 @@ class HttpDefaultTransport extends HttpTransport
             // var_dump($body);
 
             // keep count of how much data we've read
-            $response->bytesRead += strlen($body);
+            $response->bytesRead = strlen($body);
         }
         while (!$connection->feof() && ($expectedLen && $response->bytesRead < $expectedLen));
 


### PR DESCRIPTION
Fix issue in `HttpDefaultTransport` where response bodies greater than one line would be truncated due to a miscalculation of bytesRead.
